### PR TITLE
fix: string equality logic

### DIFF
--- a/com.eclipsesource.tabris.demos/src/com/eclipsesource/tabris/demos/enron/EnronDatasetIndexer.java
+++ b/com.eclipsesource.tabris.demos/src/com/eclipsesource/tabris/demos/enron/EnronDatasetIndexer.java
@@ -102,7 +102,7 @@ class EnronDatasetIndexer {
         if( indexOfSubject != -1 ) {
           subjectFound = true;
           String subjectText = line.substring( indexOfSubject + subject.length(), line.length() );
-          if( !"".equals( subjectText ) ) {
+          if( !( subjectText != null && subjectText.isEmpty() ) ) {
             result[ 0 ] = subjectText;
           }
         }
@@ -110,7 +110,7 @@ class EnronDatasetIndexer {
         if( indexOfFrom != -1 ) {
           fromFound = true;
           String fromText = line.substring( indexOfFrom + from.length(), line.length() );
-          if( !"".equals( fromText ) ) {
+          if( !( fromText != null && fromText.isEmpty() ) ) {
             result[ 1 ] = fromText;
           }
         }

--- a/com.eclipsesource.tabris.demos/src/com/eclipsesource/tabris/demos/enron/EnronExample.java
+++ b/com.eclipsesource.tabris.demos/src/com/eclipsesource/tabris/demos/enron/EnronExample.java
@@ -227,7 +227,7 @@ public class EnronExample {
           sender = line.substring( "From:".length() ).trim();
         } else if( line.startsWith( "Subject:" ) ) {
           subject = line.substring( "Subject:".length() ).trim();
-        } else if( "".equals( line.trim() ) ) {
+        } else if( line.trim().isEmpty() ) {
           headerFinished = true;
         }
       }


### PR DESCRIPTION
In file: EnronDatasetIndexer.java and EnronExample.java, there are methods that check if a String is empty using equals method. It is better to do the emptiness check using String.isEmpty method as it has less overhead than String.equals method.

Instead of using
```java
if( !"".equals( fromText ) ) {
```
It is better to use
```java
if( fromText != null && !fromText.isEmpty()) {
```
This PR suggests that fix.

##### Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.